### PR TITLE
change the version of go-reuseport to v0.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/smallnest/1m-go-tcp-server
 go 1.15
 
 require (
-	github.com/libp2p/go-reuseport v0.2.0
+	github.com/libp2p/go-reuseport v0.0.2
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	golang.org/x/sys v0.0.0-20201223074533-0d417f636930
 )


### PR DESCRIPTION
go-reuseport  v0.2.0 does not exist now, the latest tag of go-reuseport  is v0.0.2